### PR TITLE
chore: add rubocop.yml file, fix the multiple rubocop offenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /yarn-error.log
 
 .byebug_history
+.env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,503 @@
+#    _____               ____ ____        __     _         __
+#   / ___/ _____ ____ _ / __// __/____   / /    (_)____   / /_
+#   \__ \ / ___// __ `// /_ / /_ / __ \ / /    / // __ \ / __/
+#  ___/ // /__ / /_/ // __// __// /_/ // /___ / // / / // /_
+# /____/ \___/ \__,_//_/  /_/ 1 \____//_____//_//_/ /_/ \__/
+#
+# The linter file that doesn't lead junior developers to bad habits.
+# https://github.com/makersacademy/scaffolint
+#
+# Tested with Rubocop version 0.56.0
+#
+# Introduction
+# ============
+#
+# Our order of priorities:
+#
+#   1. Conforming your code to the styleguide.
+#   2. The styleguide being thorough and complete.
+#
+# This file relaxes Rubocop a bit so you can learn about code quality rather
+# than just following the rules. Some guidelines can result in worse code if you
+# don't know why they are there. For instance, if a line is too long, you might
+# be tempted to simply abbreviate your variable names - making your code harder
+# to read.
+#
+# We prioritize rules that offer good, easily incorporated feedback on improving
+# your code, without being overwhelming or requiring experienced judgement.
+#
+# As you become a better developer you will remove or amend this file according
+# to what you think good code should look like.
+#
+
+AllCops:
+  Excludes:
+    - 'bin/*'
+    - Gemfile
+    - Rakefile
+    - 'config/environments/*'
+    - 'spec/**/*'
+    - 'config/initializers/*'
+    - 'db/**/*'
+    - 'config/**/*'
+
+# Physical Code Size
+# ==================
+#
+# Sometimes beginner devs interpret line or block length restrictions as a
+# reason to make things so abbreviated as to be unreadable. These messages are
+# designed to make you write more readable code - not less.
+
+Metrics/LineLength:
+  Max: 100
+
+# We want to encourage testing, but it can be verbose in the early stages.
+# So we'll give you a break. As you learn, try removing the next two sections.
+
+Metrics/LineLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'spec/*'
+    - 'test/**/*'
+    - 'bin/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'bin/*'
+
+# Code Style
+# ==========
+#
+# Many devs, upon running a linter for the first time, see a big wall of errors
+# of dubious necessity and put it in the 'way too much trouble' box. Beginners
+# usually have far more pressing concerns than which sort of quotes they use.
+#
+# This makes Rubocop have a bigger 'payoff' for beginners without so much of
+# the punishment. We focus our linting on things that significantly impact
+# readability, expressiveness, or teach a dev new things. For example:
+#
+#   * Indentation & whitespace (inconsistency, really gross stuff like `a=1`)
+#   * Easy wins in expressiveness (e.g. guard clauses — nice opportunity to
+#     inject concretes)
+#   * Egregious non-idiomatic ruby like `def getFilename`
+
+IndentationConsistency:
+  Enabled: true
+IndentationWidth:
+  Enabled: true
+AccessorMethodName:
+  Enabled: true
+BlockEndNewline:
+  Enabled: true
+DefWithParentheses:
+  Enabled: true
+EmptyLineBetweenDefs:
+  Enabled: true
+EmptyLines:
+  Enabled: true
+ExtraSpacing:
+  Enabled: true
+GuardClause:
+  Enabled: true
+IdenticalConditionalBranches:
+  Enabled: true
+InverseMethods:
+  Enabled: true
+LeadingCommentSpace:
+  Enabled: true
+NegatedIf:
+  Enabled: true
+NegatedWhile:
+  Enabled: true
+NilComparison:
+  Enabled: true
+Not:
+  Enabled: true
+NumericLiterals:
+  Enabled: true
+NumericPredicate:
+  Enabled: true
+OneLineConditional:
+  Enabled: true
+RedundantParentheses:
+  Enabled: true
+RedundantSelf:
+  Enabled: true
+Style/SafeNavigation:
+  Enabled: true
+SelfAssignment:
+  Enabled: true
+SpaceAfterColon:
+  Enabled: true
+SpaceAfterComma:
+  Enabled: true
+SpaceAfterMethodName:
+  Enabled: true
+SpaceAfterNot:
+  Enabled: true
+SpaceAfterSemicolon:
+  Enabled: true
+SpaceAroundBlockParameters:
+  Enabled: true
+SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+SpaceAroundKeyword:
+  Enabled: true
+SpaceAroundOperators:
+  Enabled: true
+SpaceBeforeBlockBraces:
+  Enabled: true
+SpaceBeforeComma:
+  Enabled: true
+SpaceBeforeComment:
+  Enabled: true
+SpaceBeforeFirstArg:
+  Enabled: true
+SpaceBeforeSemicolon:
+  Enabled: true
+SpaceInLambdaLiteral:
+  Enabled: true
+SpaceInsideArrayPercentLiteral:
+  Enabled: true
+SpaceInsideBlockBraces:
+  Enabled: true
+SpaceInsideReferenceBrackets:
+  Enabled: true
+SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+SpaceInsideHashLiteralBraces:
+  Enabled: true
+SpaceInsideParens:
+  Enabled: true
+SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+SpaceInsideRangeLiteral:
+  Enabled: true
+SpaceInsideStringInterpolation:
+  Enabled: true
+SymbolLiteral:
+  Enabled: true
+TrailingBlankLines:
+  Enabled: true
+TrivialAccessors:
+  Enabled: true
+
+# Rubocop doesn't make disabling all cops in a given group easy, so we list...
+AccessModifierIndentation:
+  Enabled: false
+Alias:
+  Enabled: false
+AlignArray:
+  Enabled: false
+AlignHash:
+  Enabled: false
+AlignParameters:
+  Enabled: false
+AndOr:
+  Enabled: false
+ArrayJoin:
+  Enabled: false
+AsciiComments:
+  Enabled: false
+AsciiIdentifiers:
+  Enabled: false
+Attr:
+  Enabled: false
+AutoResourceCleanup:
+  Enabled: false
+BarePercentLiterals:
+  Enabled: false
+BeginBlock:
+  Enabled: false
+BlockComments:
+  Enabled: false
+BlockDelimiters:
+  Enabled: false
+BracesAroundHashParameters:
+  Enabled: false
+CaseEquality:
+  Enabled: false
+CaseIndentation:
+  Enabled: false
+CharacterLiteral:
+  Enabled: false
+ClassAndModuleChildren:
+  Enabled: false
+ClassCheck:
+  Enabled: false
+ClassMethods:
+  Enabled: false
+ClassVars:
+  Enabled: false
+ClosingParenthesisIndentation:
+  Enabled: false
+CollectionMethods:
+  Enabled: false
+ColonMethodCall:
+  Enabled: false
+CommandLiteral:
+  Enabled: false
+CommentAnnotation:
+  Enabled: false
+CommentIndentation:
+  Enabled: false
+ConditionalAssignment:
+  Enabled: false
+Copyright:
+  Enabled: false
+Documentation:
+  Enabled: false
+DocumentationMethod:
+  Enabled: false
+DotPosition:
+  Enabled: false
+DoubleNegation:
+  Enabled: false
+EachForSimpleLoop:
+  Enabled: false
+EachWithObject:
+  Enabled: false
+ElseAlignment:
+  Enabled: false
+EmptyCaseCondition:
+  Enabled: false
+EmptyElse:
+  Enabled: false
+EmptyLineAfterMagicComment:
+  Enabled: false
+EmptyLinesAroundAccessModifier:
+  Enabled: false
+EmptyLinesAroundBeginBody:
+  Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
+EmptyLinesAroundClassBody:
+  Enabled: false
+EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+EmptyLinesAroundMethodBody:
+  Enabled: false
+EmptyLinesAroundModuleBody:
+  Enabled: false
+EmptyLiteral:
+  Enabled: false
+EmptyMethod:
+  Enabled: false
+Encoding:
+  Enabled: false
+EndBlock:
+  Enabled: false
+EndOfLine:
+  Enabled: false
+EvenOdd:
+  Enabled: false
+FirstArrayElementLineBreak:
+  Enabled: false
+FirstHashElementLineBreak:
+  Enabled: false
+FirstMethodArgumentLineBreak:
+  Enabled: false
+FirstMethodParameterLineBreak:
+  Enabled: false
+FirstParameterIndentation:
+  Enabled: false
+FlipFlop:
+  Enabled: false
+For:
+  Enabled: false
+FormatString:
+  Enabled: false
+FrozenStringLiteralComment:
+  Enabled: false
+GlobalVars:
+  Enabled: false
+HashSyntax:
+  Enabled: false
+IfInsideElse:
+  Enabled: false
+IfUnlessModifier:
+  Enabled: false
+IfUnlessModifierOfIfUnless:
+  Enabled: false
+IfWithSemicolon:
+  Enabled: false
+ImplicitRuntimeError:
+  Enabled: false
+IndentArray:
+  Enabled: false
+IndentAssignment:
+  Enabled: false
+IndentHash:
+  Enabled: false
+IndentHeredoc:
+  Enabled: false
+InfiniteLoop:
+  Enabled: false
+InitialIndentation:
+  Enabled: false
+InlineComment:
+  Enabled: false
+Lambda:
+  Enabled: false
+LambdaCall:
+  Enabled: false
+LineEndConcatenation:
+  Enabled: false
+MethodCallWithArgsParentheses:
+  Enabled: false
+MethodCallWithoutArgsParentheses:
+  Enabled: false
+MethodCalledOnDoEndBlock:
+  Enabled: false
+MethodDefParentheses:
+  Enabled: false
+MethodMissingSuper:
+  Enabled: false
+MissingRespondToMissing:
+  Enabled: false
+MissingElse:
+  Enabled: false
+MixinGrouping:
+  Enabled: false
+ModuleFunction:
+  Enabled: false
+MultilineArrayBraceLayout:
+  Enabled: false
+MultilineAssignmentLayout:
+  Enabled: false
+MultilineBlockChain:
+  Enabled: false
+MultilineBlockLayout:
+  Enabled: false
+MultilineHashBraceLayout:
+  Enabled: false
+MultilineIfModifier:
+  Enabled: false
+MultilineIfThen:
+  Enabled: false
+MultilineMemoization:
+  Enabled: false
+MultilineMethodCallBraceLayout:
+  Enabled: false
+MultilineMethodCallIndentation:
+  Enabled: false
+MultilineMethodDefinitionBraceLayout:
+  Enabled: false
+MultilineOperationIndentation:
+  Enabled: false
+MultilineTernaryOperator:
+  Enabled: false
+MutableConstant:
+  Enabled: false
+NestedModifier:
+  Enabled: false
+NestedParenthesizedCalls:
+  Enabled: false
+NestedTernaryOperator:
+  Enabled: false
+Next:
+  Enabled: false
+NonNilCheck:
+  Enabled: false
+NumericLiteralPrefix:
+  Enabled: false
+BinaryOperatorParameterName:
+  Enabled: false
+OptionHash:
+  Enabled: false
+OptionalArguments:
+  Enabled: false
+ParallelAssignment:
+  Enabled: false
+ParenthesesAroundCondition:
+  Enabled: false
+PercentLiteralDelimiters:
+  Enabled: false
+PercentQLiterals:
+  Enabled: false
+PerlBackrefs:
+  Enabled: false
+PreferredHashMethods:
+  Enabled: false
+Proc:
+  Enabled: false
+RaiseArgs:
+  Enabled: false
+RedundantBegin:
+  Enabled: false
+RedundantException:
+  Enabled: false
+RedundantFreeze:
+  Enabled: false
+RedundantReturn:
+  Enabled: false
+RegexpLiteral:
+  Enabled: false
+RescueEnsureAlignment:
+  Enabled: false
+RescueModifier:
+  Enabled: false
+Semicolon:
+  Enabled: false
+Send:
+  Enabled: false
+SignalException:
+  Enabled: false
+SingleLineBlockParams:
+  Enabled: false
+SingleLineMethods:
+  Enabled: false
+SpecialGlobalVars:
+  Enabled: false
+StabbyLambdaParentheses:
+  Enabled: false
+StringLiterals:
+  Enabled: false
+StringLiteralsInInterpolation:
+  Enabled: false
+StringMethods:
+  Enabled: false
+StructInheritance:
+  Enabled: false
+SymbolArray:
+  Enabled: false
+SymbolProc:
+  Enabled: false
+Tab:
+  Enabled: false
+TernaryParentheses:
+  Enabled: false
+TrailingCommaInArguments:
+  Enabled: false
+TrailingCommaInArrayLiteral:
+  Enabled: false
+TrailingCommaInHashLiteral:
+  Enabled: false
+TrailingUnderscoreVariable:
+  Enabled: false
+TrailingWhitespace:
+  Enabled: false
+UnlessElse:
+  Enabled: false
+UnneededCapitalW:
+  Enabled: false
+UnneededInterpolation:
+  Enabled: false
+UnneededPercentQ:
+  Enabled: false
+VariableInterpolation:
+  Enabled: false
+VariableNumber:
+  Enabled: false
+WhenThen:
+  Enabled: false
+WhileUntilDo:
+  Enabled: false
+WhileUntilModifier:
+  Enabled: false
+WordArray:
+  Enabled: false
+ZeroLengthPredicate:
+  Enabled: false


### PR DESCRIPTION
added back in rubocop.yml that had mysteriously disappeared 