### PR TITLE
refactor: create post now accepts user_id as argument

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,7 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.create(message: post_params[:message])
+    @post = Post.create(message: post_params[:message], user_id: post_params[:user_id])
     render json: @post
   end
 
@@ -18,6 +18,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:message)
+    params.require(:post).permit(:message, :user_id)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,4 @@ Rails.application.routes.draw do
     resources :likes
   end
 
-  root 'posts#index'
-
 end


### PR DESCRIPTION
- Modify posts#create to take user_id from params when new post is created. 
- Removed homepage redirection to /posts. 